### PR TITLE
Fixed missing c++11 specifier

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -2,4 +2,4 @@ PKG_CXXFLAGS += -I../inst/include -I.
 PKG_CFLAGS += -I../inst/include -I.
 PKG_CPPFLAGS=$(shell Rscript -e "Rcpp:::CxxFlags()" )
 PKG_LIBS = $(shell Rscript -e "Rcpp:::LdFlags()" )
-CXXOPTS = $(shell Rscript -e "Rcpp:::Cxx0xFlags()" )
+CXX_STD=CXX11


### PR DESCRIPTION
Suggested change to Makevars, it doesn't work with the intel compiler as is. CXXOPTS may be gcc specific?
